### PR TITLE
add ICP instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017, International Business Machines Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ Leveraging Kubernetes concepts like Replication Controller, StatefulSets we prov
 
 ## Prerequisite
 
-Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template) to deploy in cloud. The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
+Create a Kubernetes cluster with either:
+* [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing
+* [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template) to deploy in cloud, or
+* [IBM Cloud Private](https://www.ibm.com/cloud-computing/products/ibm-cloud-private/) for either senario.
+For deploying on IBM Cloud Private follow the instructions [here](docs/deploy-with-ICP.md)
+The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
 
 ## Deploy to Kubernetes Cluster from Bluemix
 If you want to deploy Cassandra nodes directly to Bluemix, click on 'Deploy to Bluemix' button below to create a Bluemix DevOps service toolchain and pipeline for deploying the sample, else jump to [Steps](#steps)

--- a/docs/deploy-with-ICP.md
+++ b/docs/deploy-with-ICP.md
@@ -1,0 +1,26 @@
+# Deploy with IBM Cloud Private
+
+Follow the [instructions](https://github.com/IBM/deploy-ibm-cloud-private)
+to either install a local instance of IBM Cloud private via Vagrant or a remote
+instance at Softlayer. These instructions assume the former.
+
+The local option uses Vagrant to create an instance of IBM Cloud Private within
+a virtual machine.  The Vagrantfile in those instructions installs kubectl on
+this VM.  To access your Vagrant VM:
+
+```bash
+$ vagrant ssh
+```
+
+From this promt inside the VM, clone this repo to make use of the included yaml
+files.
+
+```bash
+$ git clone https://github.com/IBM/Scalable-Cassandra-deployment-on-Kubernetes.git
+$ cd Scalable-Cassandra-deployment-on-Kubernetes
+```
+
+From here, you can follow along with the instructions in the
+[root](../#1-create-a-cassandra-headless-service) of this repo to deploy
+Cassandra.
+


### PR DESCRIPTION
adds a document with some brief instructions on how to get started with the repo using ICP.  adds a reference to the doc within the root README

also, adds company info to the LICENSE file