### PR TITLE
update link back to README

### DIFF
--- a/docs/deploy-with-ICP.md
+++ b/docs/deploy-with-ICP.md
@@ -21,6 +21,4 @@ $ cd Scalable-Cassandra-deployment-on-Kubernetes
 ```
 
 From here, you can follow along with the instructions in the
-[root](../#1-create-a-cassandra-headless-service) of this repo to deploy
-Cassandra.
-
+[root](../README.md#1-create-a-cassandra-headless-service#1-create-a-cassandra-headless-service) of this repo to deploy Cassandra.


### PR DESCRIPTION
fix 404 on relative link in `docs/deploy-with-ICP.md`  when viewing on Github