### PR TITLE
Remove sudo and dist tags from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: required
 
 language: python
 python: 2.7


### PR DESCRIPTION
Remove 'sudo: required' and 'dist: trusty' from the .travis.yml
file.  Both are depricated.

Fixes #46 